### PR TITLE
configure.ac: add AC_SEARCH_LIBS routine for libpcre

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_SEARCH_LIBS([rs_create_context], [realsense], [AM_CONDITIONAL([HAVE_REALSENSE], true)], [AM_CONDITIONAL([HAVE_REALSENSE], false)])
+AC_SEARCH_LIBS([pcre_study], [pcre], [], [ AC_MSG_ERROR([unable to find the pcre_study() function]) ])
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE


### PR DESCRIPTION
Somehow it fixes linking glib-2.0 during a cross compile.

Before this addition make failed during linking like this:

```
/usr/lib/gcc-cross/arm-linux-gnueabihf/5/../../../../arm-linux-gnueabihf/bin/ld:
/data/george/images/beta/raspbian/rootfs/usr/lib/arm-linux-gnueabihf/libglib-2.0.a(libglib_2_0_la-gregex.o):
undefined reference to symbol 'pcre_study'
/data/george/images/beta/raspbian/rootfs/lib/arm-linux-gnueabihf/libpcre.so.3:
error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
M
```

Configured as follows:

`> cat sysroot-gcc`

```bash
#!/bin/bash -x
exec arm-linux-gnueabihf-gcc --sysroot=$SYSROOT "$@"
```

`> cat env.sh`

```bash
export SYSROOT=/data/george/images/beta/raspbian/rootfs

export PKG_CONFIG_DIR=
export PKG_CONFIG_SYSROOT_DIR=${SYSROOT}
export PKG_CONFIG_LIBDIR=${SYSROOT}/usr/lib/pkgconfig:${SYSROOT}/usr/share/pkgconfig:${SYSROOT}/usr/lib/arm-linux-gnueabihf/pkgconfig
```
`> source env.sh`

`> ./configure  CC=./sysroot-gcc CXX=./sysroot-g++ --prefix=/usr
--build=x86_64-linux-gnu --host=arm-linux-gnueabihf`

Also I wanted to ask about the purpose of `--with-rootlib` switch. It seems like it's not handled in Makefile.am. I'm also curious why `--with-sysroot` doesn't seem to change a thing. The compilation fails if I don't use these sysroot-gcc and sysroot-g++ hacks.

