### PR TITLE
[WIP] Test apps: Clean up client app to test mavlink protocol

### DIFF
--- a/test/test_mavlink_protocol.cpp
+++ b/test/test_mavlink_protocol.cpp
@@ -16,8 +16,17 @@
  * limitations under the License.
  */
 
+/**
+
+@brief  This is  a test application to test mavlink messages in the Camera Streaming Daemon.
+
+*/
+
 #include <assert.h>
 #include <mavlink.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <thread>
 #include <unistd.h>
 
 #include "glib_mainloop.h"
@@ -29,40 +38,82 @@
 #define MAX_STREAMS 25
 #define GCS_SYSID 255
 
-struct stream {
-    int id;
-    const char *name;
-};
+using namespace std;
 
-struct Context {
+class Drone {
+public:
+    enum Mode { NONE = -1, IMAGE, VIDEO, SURVEY };
+    Drone();
+    bool setMode(int camera_id, int mode);
+    int getMode(int camera_id);
+    void imageCapture(int camera_id, int count, int interval);
+    std::vector<int> getCameraIdList() const;
+    std::string getCameraName(int camera_id) const;
+    bool getCameraStream(int camera_id) const;
+
+private:
+    struct Stream {
+        int id;
+        std::string name;
+        Mode mode;
+    };
     UDPSocket udp;
-    int connected_camera_sysid = 0;
-    struct stream streams[MAX_STREAMS];
-    uint8_t streams_size;
+    int sysid = 0;
+    std::vector<Stream> streams;
+    struct sockaddr_in addr;
+    struct buffer buf;
+    bool sendCameraMsg(mavlink_message_t &msg);
+    void handleCameraInformationCB(mavlink_message_t &msg);
+    void handleCameraSettingsCB(mavlink_message_t &msg);
+    void handleHeartbeatCB(mavlink_message_t &msg);
+    void handleAckCB(mavlink_message_t &msg);
+    void handleMavlinkMessageCB(mavlink_message_t &msg);
+    void messageReceivedCB();
 };
 
-static void reprint_streams(struct Context &ctx)
+Drone::Drone()
 {
-    log_info("\n");
-    if (ctx.streams_size == 0) {
-        log_info("No streams found.");
-        return;
-    }
+    udp.open(false);
+    udp.bind("0.0.0.0", 14550);
+    udp.set_read_callback([this](const struct buffer &buff, const struct sockaddr_in &sockaddr) {
+        addr = sockaddr;
+        buf = buff;
+        messageReceivedCB();
+    });
+}
 
-    log_info("Streams found:");
-    for (int i = 0; i < ctx.streams_size; i++) {
-        log_info("%d - %s", ctx.streams[i].id, ctx.streams[i].name);
+std::vector<int> Drone::getCameraIdList() const
+{
+    std::vector<int> camera_id_list;
+    if (streams.size() == 0) {
+        log_info("No streams found.");
+
+    } else {
+        for (std::vector<Stream>::const_iterator id_list = streams.begin();
+             id_list != streams.end(); ++id_list) {
+            camera_id_list.push_back(id_list->id);
+        }
+        return camera_id_list;
     }
 }
 
-static bool send_camera_msg(struct Context &ctx, const struct sockaddr_in &addr,
-                            mavlink_message_t &msg)
+std::string Drone::getCameraName(int camera_id) const
+{
+
+    for (auto camera : streams) {
+        if (camera.id == camera_id)
+            return camera.name;
+    }
+    return nullptr;
+}
+
+bool Drone::sendCameraMsg(mavlink_message_t &msg)
 {
     uint8_t buffer[BUF_LEN];
-    struct buffer buf = {0, buffer};
+    struct buffer buff = {0, buffer};
 
-    buf.len = mavlink_msg_to_send_buffer(buf.data, &msg);
-    if (!buf.len || ctx.udp.write(buf, addr) < 0) {
+    buff.len = mavlink_msg_to_send_buffer(buff.data, &msg);
+    if (!buff.len || udp.write(buff, addr) < 0) {
         log_error("Sending camera request failed.");
         return false;
     }
@@ -70,164 +121,246 @@ static bool send_camera_msg(struct Context &ctx, const struct sockaddr_in &addr,
     return true;
 }
 
-static int read_int()
+bool Drone::getCameraStream(int camera_id) const
 {
-    char *text = nullptr;
-    int ret, value;
-    ssize_t read;
-    size_t n, len;
 
-    do {
-        read = getline(&text, &n, stdin);
-        if (read <= 0) {
-            log_error("Reading input failed. aborting");
-            exit(EXIT_FAILURE);
-            return 0;
-        }
+    for (auto camera : streams) {
+        if (camera.id == camera_id)
+            return 1;
+    }
+    return 0;
+}
 
-        len = strlen(text);
-        if (len > 0) {
-            text[len - 1] = 0;
-            ret = safe_atoi(text, &value);
-            if (ret >= 0) {
-                free(text);
-                return value;
+bool Drone::setMode(int camera_id, int mode)
+{
+    bool success;
+    mavlink_message_t out_msg;
+    if (mode == IMAGE) {
+        mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, sysid, camera_id,
+                                      MAV_CMD_SET_CAMERA_MODE, 0, 0, 0, 0, 0, 0, 0, 0);
+        log_info("MAV_CMD_SET_CAMERA_MODE sent");
+        sendCameraMsg(out_msg);
+        success = 1;
+    } else if (mode == VIDEO) {
+        mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, sysid, camera_id,
+                                      MAV_CMD_SET_CAMERA_MODE, 0, 0, 1, 0, 0, 0, 0, 0);
+        log_info("MAV_CMD_SET_CAMERA_MODE sent");
+        sendCameraMsg(out_msg);
+        success = 1;
+    } else {
+        log_info("Mode value is invalid.");
+        success = 0;
+    }
+    return success;
+}
+
+int Drone::getMode(int camera_id)
+{
+    mavlink_message_t out_msg;
+    mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, sysid, camera_id,
+                                  MAV_CMD_REQUEST_CAMERA_SETTINGS, 0, 1, 0, 0, 0, 0, 0, 0);
+    log_info("MAV_CMD_REQUEST_CAMERA_SETTINGS sent");
+    sendCameraMsg(out_msg);
+
+    for (auto &i : streams) {
+        if (i.id == camera_id) {
+            while (i.mode == NONE) {
+                sleep(1);
             }
+            return i.mode;
         }
-
-        log_error("Invalid value. Try again:");
-    } while (true);
+    }
 }
 
-static struct stream *get_camera_stream(struct Context &ctx, int camera_id)
+void Drone::imageCapture(int camera_id, int count, int interval)
 {
-    for (int i = 0; i < ctx.streams_size; i++) {
-        if (ctx.streams[i].id == camera_id)
-            return &ctx.streams[i];
-    }
-
-    return nullptr;
+    mavlink_message_t out_msg;
+    mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, sysid, camera_id,
+                                  MAV_CMD_IMAGE_START_CAPTURE, 0, interval, count, 1, 0, 0, 0, 0);
+    log_info("MAV_CMD_IMAGE_START_CAPTURE sent");
+    sendCameraMsg(out_msg);
 }
 
-static void play_stream(struct Context &ctx, const struct sockaddr_in &addr)
+void Drone::handleHeartbeatCB(mavlink_message_t &msg)
 {
-    int h, v, camera_id;
-    struct stream *s;
-
-    log_info("Please make your selection (type stream number):");
-    camera_id = read_int();
-    s = get_camera_stream(ctx, camera_id);
-
-    if (!s) {
-        log_error("Camera not found.");
-        return;
+    if (msg.sysid == sysid) {
+        for (auto i : streams)
+            if (msg.compid == i.id) {
+                return;
+            }
     }
 
-    log_info("Select Horizontal resolution (0 for default): ");
-    h = read_int();
-
-    log_info("Select Vertical resolution (0 for default): ");
-    v = read_int();
+    log_info("Camera Daemon found: sysid: %d comp_id: %d", msg.sysid, msg.compid);
+    sysid = msg.sysid;
 
     mavlink_message_t out_msg;
-    mavlink_msg_set_video_stream_settings_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg,
-                                               ctx.connected_camera_sysid, MAV_COMP_ID_CAMERA,
-                                               camera_id, 0, h, v, 0, 0, "");
-
-    send_camera_msg(ctx, addr, out_msg);
-
-    mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, ctx.connected_camera_sysid,
-                                  MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION, 0,
-                                  camera_id, 1, 0, 0, 0, 0, 0);
-
-    send_camera_msg(ctx, addr, out_msg);
+    mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg, sysid, msg.compid,
+                                  MAV_CMD_REQUEST_CAMERA_INFORMATION, 0, 1, 0, 0, 0, 0, 0, 0);
+    log_info("MAV_CMD_REQUEST_CAMERA_INFORMATION sent");
+    sendCameraMsg(out_msg);
 }
 
-static void handle_mavlink_message(struct Context &ctx, const struct sockaddr_in &addr, mavlink_message_t &msg)
+void Drone::handleCameraInformationCB(mavlink_message_t &msg)
 {
-    if (msg.compid != MAV_COMP_ID_CAMERA)
-        return;
+    mavlink_camera_information_t info;
+    mavlink_msg_camera_information_decode(&msg, &info);
+    struct Stream s;
+    s.mode = NONE;
+    s.id = msg.compid;
+    s.name = std::string((char *)info.model_name);
+    streams.push_back(s);
+}
 
-    if (msg.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
-        if (msg.sysid == ctx.connected_camera_sysid)
-            return;
+void Drone::handleCameraSettingsCB(mavlink_message_t &msg)
+{
+    log_info("Got MAVLINK_MSG_ID_CAMERA_SETTINGS");
+    mavlink_camera_settings_t settings;
+    mavlink_msg_camera_settings_decode(&msg, &settings);
 
-        log_info("Camera Daemon found: sysid: %d", msg.sysid);
-        ctx.connected_camera_sysid = msg.sysid;
-
-        mavlink_message_t out_msg;
-        mavlink_msg_command_long_pack(GCS_SYSID, MAV_COMP_ID_ALL, &out_msg,
-                                      ctx.connected_camera_sysid, MAV_COMP_ID_CAMERA,
-                                      MAV_CMD_REQUEST_CAMERA_INFORMATION, 0, 0, 1, 0, 0, 0, 0, 0);
-
-        send_camera_msg(ctx, addr, out_msg);
-    } else if (msg.msgid == MAVLINK_MSG_ID_CAMERA_INFORMATION) {
-        mavlink_camera_information_t info;
-        mavlink_msg_camera_information_decode(&msg, &info);
-
-        ctx.streams[ctx.streams_size].id = msg.compid;
-        ctx.streams[ctx.streams_size++].name = strdup((const char *)info.model_name);
-    } else if (msg.msgid == MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION) {
-        char cmd[300];
-        int ret;
-        mavlink_video_stream_information_t info;
-
-        mavlink_msg_video_stream_information_decode(&msg, &info);
-
-        log_info("Stream Information:");
-        log_info("   Status: %s", info.status == 1 ? "streaming" : "not streaming");
-        log_info("   Resolution: %dx%d", info.resolution_h, info.resolution_v);
-        log_info("   URI: %s", info.uri);
-
-        if (info.status == 1) {
-            log_info("Video is already streaming to another client.");
-            exit(EXIT_FAILURE);
-        } else {
-            ret = snprintf(cmd, sizeof(cmd),
-                    "gst-launch-1.0 rtspsrc location=\"%s\" ! decodebin ! autovideosink sync=false",
-                    info.uri);
-            if (ret >= (int)sizeof(cmd) || system(cmd) <= 0) {
-                log_error("Unable to start video stream. Start it manually.");
-            }
-        }
-    } else if (msg.msgid == MAVLINK_MSG_ID_COMMAND_ACK) {
-        mavlink_command_ack_t ack;
-        mavlink_msg_command_ack_decode(&msg, &ack);
-        if (ack.command == MAV_CMD_REQUEST_CAMERA_INFORMATION) {
-            reprint_streams(ctx);
-            play_stream(ctx, addr);
+    for (auto &i : streams) {
+        if (i.id == msg.compid) {
+            i.mode = (Mode)settings.mode_id;
         }
     }
 }
 
-static void message_received(struct Context &ctx, const struct sockaddr_in &addr, const struct buffer &buf)
+void Drone::handleAckCB(mavlink_message_t &msg)
+{
+    mavlink_command_ack_t ack;
+    mavlink_msg_command_ack_decode(&msg, &ack);
+    if (ack.command == MAV_CMD_IMAGE_START_CAPTURE) {
+        log_info("Acknowledgement for MAV_CMD_IMAGE_START_CAPTURE recieved");
+        return;
+    }
+}
+
+void Drone::handleMavlinkMessageCB(mavlink_message_t &msg)
+{
+
+    if (msg.compid < MAV_COMP_ID_CAMERA2) {
+        return;
+    }
+
+    switch (msg.msgid) {
+    case MAVLINK_MSG_ID_HEARTBEAT:
+        handleHeartbeatCB(msg);
+        break;
+    case MAVLINK_MSG_ID_CAMERA_INFORMATION:
+        handleCameraInformationCB(msg);
+        break;
+    case MAVLINK_MSG_ID_CAMERA_SETTINGS:
+        handleCameraSettingsCB(msg);
+        break;
+    case MAVLINK_MSG_ID_COMMAND_ACK:
+        handleAckCB(msg);
+        break;
+    default:
+        log_info("%d  message is not handled.", msg.msgid);
+    }
+}
+
+void Drone::messageReceivedCB()
 {
     mavlink_message_t msg;
     mavlink_status_t status;
 
     for (unsigned int i = 0; i < buf.len; ++i) {
         if (mavlink_parse_char(MAVLINK_COMM_0, buf.data[i], &msg, &status)) {
-            handle_mavlink_message(ctx, addr, msg);
+            handleMavlinkMessageCB(msg);
         }
     }
 }
-
-int main(int argc, char *argv[])
+// Thread to handle mavlink messages
+void *discovercam(void *cntx)
 {
-    Context ctx = {};
     GlibMainloop mainloop;
 
+    class Drone **ctx = (class Drone **)cntx;
+    *ctx = new Drone();
+
+    mainloop.loop();
+}
+int main(int argc, char *argv[])
+{
+    int camera_id;
     Log::open();
     Log::set_max_level(Log::Level::INFO);
     log_debug("Camera Streaming MAVLink Client");
 
-    ctx.udp.open(false);
-    ctx.udp.bind("0.0.0.0", 14550);
-    ctx.udp.set_read_callback([&ctx](const struct buffer &buf, const struct sockaddr_in &sockaddr) {
-        message_received(ctx, sockaddr, buf);
-    });
+    class Drone *ctx;
+    std::thread t_id;
+    t_id = std::thread(discovercam, (void *)&ctx);
+    sleep(5);
+    auto camera_list = ctx->getCameraIdList();
+    log_info("\n");
+    if (camera_list.size() == 0) {
+        log_info("No streams found.");
+        exit(EXIT_FAILURE);
+    }
+    for (auto camera : camera_list) {
+        log_info("%d-%s", camera, (ctx->getCameraName(camera)).c_str());
+    }
 
-    mainloop.loop();
+    log_info("Please make your selection (type stream number):");
+    scanf("%d", &camera_id);
+    if (!ctx->getCameraStream(camera_id)) {
+        log_error("Camera not found.");
+        exit(EXIT_FAILURE);
+        ;
+    }
+
+    do {
+        log_info("\nSelect an action\n 1.Set Mode\n 2.Get Mode\n 3.Image Capture\n 4.Exit");
+        int option;
+        scanf("%d", &option);
+        switch (option) {
+        case 1: {
+            log_info("Select mode 0:image 1:video 2:image survey");
+            int mode;
+            scanf("%d", &mode);
+            ctx->setMode(camera_id, mode);
+            break;
+        }
+        case 2: {
+            int mode = ctx->getMode(camera_id);
+            sleep(1);
+            switch (mode) {
+            case Drone::IMAGE:
+                log_info("Mode: image");
+                break;
+            case Drone::VIDEO:
+                log_info("Mode: video");
+                break;
+            case Drone::SURVEY:
+                log_info("Mode: image survey");
+                break;
+            default:
+                log_info("Mode: Invalid");
+            }
+            break;
+        }
+        case 3: {
+            log_info("Enter the number of images to be taken");
+            int count;
+            scanf("%d", &count);
+            log_info("Enter the intervel in which images to be taken");
+            int intervel;
+            scanf("%d", &intervel);
+            ctx->imageCapture(camera_id, count, intervel);
+            sleep(intervel + 1);
+            break;
+        }
+        case 4:
+            log_info("Exiting appication");
+            break;
+        default:
+            log_info("Invalid Selection");
+        }
+        if (option == 4)
+            exit(EXIT_FAILURE);
+    } while (1);
+
+    t_id.join();
 
     Log::close();
     return 0;


### PR DESCRIPTION
The app to test mavlink protocol can send/receive a small set of mavlink messages.
  
In its current form it  :
 - handles mavlink heartbeat message send by csd
 -  requests and receives camera information
 - sets mode based on user input (if camera supports set mode)
 - gets the mode from camera using 
 - sends mavlink command for image capture

Steps to test:
1) `make test` should generate executable for test apps.
2) Start csd : `./csd -v -c ./samples/config/ubuntu.conf`
3) Start the mavlink client: `./test/test-mavlink-protocol`

In order to handle mavlink messages from multiple cameras and simultaneously take input from user, a separate thread should be used. All user I/O functions are handled in main function and handling of mavlink messages is done in a thread.
