### PR TITLE
Fix log output for light themed terminals

### DIFF
--- a/src/VideoStreamRtsp.cpp
+++ b/src/VideoStreamRtsp.cpp
@@ -536,7 +536,7 @@ int VideoStreamRtsp::startRtspServer()
 
     /* attach the video to the RTSP URL */
     gst_rtsp_mount_points_add_factory(mounts, mPath.c_str(), factory);
-    log_info("RTSP stream ready at rtsp://<ip-address>:%s%s\n", std::to_string(mPort).c_str(),
+    log_info("RTSP stream ready at rtsp://<ip-address>:%s%s", std::to_string(mPort).c_str(),
              mPath.c_str());
     g_object_unref(mounts);
 

--- a/src/avahi_publisher.cpp
+++ b/src/avahi_publisher.cpp
@@ -141,7 +141,7 @@ void AvahiPublisher::publish_services(AvahiClient *c)
 
 void AvahiPublisher::start()
 {
-    log_error("AVAHI START");
+    log_info("AVAHI START");
     if (is_running)
         return;
 

--- a/src/avahi_publisher.cpp
+++ b/src/avahi_publisher.cpp
@@ -141,7 +141,7 @@ void AvahiPublisher::publish_services(AvahiClient *c)
 
 void AvahiPublisher::start()
 {
-    log_error("AVAHI START\n");
+    log_error("AVAHI START");
     if (is_running)
         return;
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -26,7 +26,6 @@
 
 #define COLOR_RED          "\033[31m"
 #define COLOR_LIGHTBLUE    "\033[34;1m"
-#define COLOR_YELLOW       "\033[33;1m"
 #define COLOR_ORANGE       "\033[0;33m"
 #define COLOR_WHITE        "\033[37;1m"
 #define COLOR_RESET        "\033[0m"
@@ -45,8 +44,6 @@ const char *Log::_get_color(Level level)
         return COLOR_RED;
     case Level::WARNING:
         return COLOR_ORANGE;
-    case Level::NOTICE:
-        return COLOR_YELLOW;
     case Level::INFO:
         return COLOR_WHITE;
     case Level::DEBUG:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -25,9 +25,9 @@
 #include <sys/uio.h>
 
 #define COLOR_RED          "\033[31m"
-#define COLOR_LIGHTBLUE    "\033[34;1m"
-#define COLOR_ORANGE       "\033[0;33m"
-#define COLOR_WHITE        "\033[37;1m"
+#define COLOR_ORANGE       "\033[33m"
+#define COLOR_BLUE         "\033[34m"
+#define COLOR_GREEN        "\033[32m"
 #define COLOR_RESET        "\033[0m"
 
 Log::Level Log::_max_level = Level::INFO;
@@ -45,9 +45,9 @@ const char *Log::_get_color(Level level)
     case Level::WARNING:
         return COLOR_ORANGE;
     case Level::INFO:
-        return COLOR_WHITE;
+        return COLOR_BLUE;
     case Level::DEBUG:
-        return COLOR_LIGHTBLUE;
+        return COLOR_GREEN;
     }
 
     return nullptr;

--- a/src/log.h
+++ b/src/log.h
@@ -28,7 +28,6 @@ public:
     enum class Level {
         ERROR = 0,
         WARNING,
-        NOTICE,
         INFO,
         DEBUG,
     };
@@ -52,7 +51,6 @@ protected:
 
 #define log_debug(...) Log::log(Log::Level::DEBUG, __VA_ARGS__)
 #define log_info(...) Log::log(Log::Level::INFO, __VA_ARGS__)
-#define log_notice(...) Log::log(Log::Level::NOTICE, __VA_ARGS__)
 #define log_warning(...) Log::log(Log::Level::WARNING, __VA_ARGS__)
 #define log_error(...) Log::log(Log::Level::ERROR, __VA_ARGS__)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ static void help(FILE *fp)
         "  -d --conf-dir <dir>              Directory where to look for .conf files overriding\n"
         "                                   default conf file.\n"
         "  -g --debug-log-level <level>     Set debug log level. Levels are\n"
-        "                                   <error|warning|notice|info|debug>\n"
+        "                                   <error|warning|info|debug>\n"
         "  -v --verbose                     Verbose. Same as --debug-log-level=debug\n"
         "  -h --help                        Print this message\n",
         program_invocation_short_name);

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -758,7 +758,7 @@ bool _heartbeat_cb(void *data)
 
 void MavlinkServer::start()
 {
-    log_error("MAVLINK START\n");
+    log_error("MAVLINK START");
     if (_is_running)
         return;
     _is_running = true;

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -758,7 +758,7 @@ bool _heartbeat_cb(void *data)
 
 void MavlinkServer::start()
 {
-    log_error("MAVLINK START");
+    log_info("MAVLINK START");
     if (_is_running)
         return;
     _is_running = true;


### PR DESCRIPTION
This fixes #188. Tested with dark and light terminals.

Also, this removes the log level `NOTICE` which was unused and to me seems the same as `INFO`.